### PR TITLE
docs: add PyPI installation instructions and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ _Map geometries to environmental semantics_
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 ![example workflow](https://github.com/clnsmth/geoenv/actions/workflows/ci-cd.yml/badge.svg)
 [![codecov](https://codecov.io/github/clnsmth/geoenv/graph/badge.svg?token=2J4MNIXCTD)](https://codecov.io/github/clnsmth/geoenv)
+<a href="https://pypi.org/project/geoenv/" target="_blank">
+    <img src="https://img.shields.io/pypi/v/geoenv?color=%2334D058&label=pypi" alt="Package version">
+</a>
 
 `geoenv` is a Python library that maps geospatial geometries, such as points and polygons, to standardized environmental terms. It’s like reverse geocoding, but for environments.
 
@@ -26,10 +29,10 @@ Finding datasets based on their environmental context is a challenge in data syn
 
 ## Quick Start
 
-Install directly from GitHub:
+Install from PyPI:
 
 ```bash
-pip install git+https://github.com/clnsmth/geoenv.git@main
+pip install geoenv
 ```
 
 Resolve a point on land:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,10 @@ Release v\ |version|. (:ref:`Installation <quickstart>`)
     :target: https://codecov.io/github/clnsmth/geoenv
     :alt: Code coverage status
 
+.. image:: https://img.shields.io/pypi/v/geoenv?color=%2334D058&label=pypi
+    :target: https://pypi.org/project/geoenv/
+    :alt: Package version
+
 `geoenv` is a Python library that maps geospatial geometries, such as points and polygons, to standardized environmental terms. It’s like reverse geocoding, but for environments.
 
 Motivation
@@ -42,11 +46,11 @@ Know of a useful data source or vocabulary? `Suggest it! <https://github.com/cln
 Quick Start
 -----------
 
-Install directly from GitHub:
+Install from PyPI:
 
 .. code-block:: bash
 
-   pip install git+https://github.com/clnsmth/geoenv.git@main
+   pip install geoenv
 
 Resolve a point on land:
 


### PR DESCRIPTION
Add PyPI installation instructions and the PyPI badge to the documentation. This enables a common method of installation and raises awareness that the package is on PyPI.