### PR TITLE
docs: align .toml project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "geoenv"
 version = "0.2.1"
-description = "A Python library that links geographic coordinates to environmental properties at a global scale."
+description = "Map geometries to environmental semantics"
 authors = ["Colin Smith <colin.smith@wisc.edu>"]
 maintainers = ["Colin Smith <colin.smith@wisc.edu>"]
 license = "MIT"


### PR DESCRIPTION
Align the .toml project description with others throughout the documentation for consistency.