### PR TITLE
fix: broken logo reference

### DIFF
--- a/docs/source/_templates/sidebarintro.html
+++ b/docs/source/_templates/sidebarintro.html
@@ -1,21 +1,13 @@
 <!--Display the project logo at the top of the sidebar-->
-<!--<p class="logo">-->
-<!--  <a href="{{ pathto(master_doc) }}">-->
-<!--    <img class="logo" src="{{ pathto('_static/project-sidebar.png', 1) }}" alt="Project logo" />-->
-<!--  </a>-->
-<!--</p>-->
-
-<p>
-  <iframe src="https://ghbtns.com/github-btn.html?user=clnsmth&repo=geoenv&type=star&size=large&text=false" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
-</p>
-
-<p>
-  A Python library that links geographic coordinates to environmental properties at a global scale.
+<p class="logo">
+  <a href="#">
+    <img class="logo" src="_static/project-sidebar.png" alt="Project logo" />
+  </a>
 </p>
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://geoenv.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
+  <li><a href="https://geoenv.readthedocs.io/en/latest/#quickstart">Quickstart</a></li>
   <li><a href="https://geoenv.readthedocs.io/en/latest/user/api.html">API Reference</a></li>
   <li><a href="https://geoenv.readthedocs.io/en/latest/CHANGELOG.html">Release History</a></li>
 

--- a/docs/source/_templates/sidebarlogo.html
+++ b/docs/source/_templates/sidebarlogo.html
@@ -1,14 +1,7 @@
-<p>
-  <iframe src="https://ghbtns.com/github-btn.html?user=clnsmth&repo=geoenv&type=star&size=large&text=false" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
-</p>
-
-<p>
-  A Python library that links geographic coordinates to environmental properties at a global scale.
-</p>
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://geoenv.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
+  <li><a href="https://geoenv.readthedocs.io/en/latest/#quickstart">Quickstart</a></li>
   <li><a href="https://geoenv.readthedocs.io/en/latest/user/api.html">API Reference</a></li>
   <li><a href="https://geoenv.readthedocs.io/en/latest/CHANGELOG.html">Release History</a></li>
 


### PR DESCRIPTION
The logo reference in the sidebar.html files is broken due to convoluted nesting within the project source docs.