### PR TITLE
test: control real requests with environmental variable

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main, development]
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
 
 jobs:
 
@@ -49,6 +51,29 @@ jobs:
     # Build docs
     - name: Build documentation
       run: poetry run make html --directory docs/
+
+
+  test-real-requests:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      GEOENV_USE_MOCK: "false"
+    steps:
+      # Set up job requirements
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Check-out repository
+        uses: actions/checkout@v4
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+      - name: Install package
+        run: poetry install --sync --with dev
+
+      # Test
+      - name: Test with pytest
+        run: poetry run pytest tests/
 
 
   cd:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Configuration for the test suite"""
 
+import os
 import json
 import tempfile
 from importlib.resources import files
@@ -14,8 +15,15 @@ from geoenv.utilities import EnvironmentDataModel
 
 @pytest.fixture()
 def use_mock():
-    """Use mock data for testing purposes."""
-    return True  # Change this to False for real HTTP requests and data
+    """
+    Use mock data for testing purposes.
+
+    Controlled by the GEOENV_USE_MOCK environment variable. If GEOENV_USE_MOCK
+    is not set, defaults to True (use mocks). Set GEOENV_USE_MOCK to 'false'
+    (case-insensitive) to disable mocks and use real HTTP requests.
+    """
+    value = os.environ.get("GEOENV_USE_MOCK", "true").lower()
+    return value not in {"false"}
 
 
 @pytest.fixture


### PR DESCRIPTION
Control real requests with an environmental variable instead of a hardcoded parameter in `conftest.py`. This enables control without changing the code and allows the CI workflow to run with both mocked and real requests.