### PR TITLE
ci: separate real request tests, add new triggers

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [main, development]
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
 
 jobs:
 
@@ -51,30 +49,6 @@ jobs:
     # Build docs
     - name: Build documentation
       run: poetry run make html --directory docs/
-
-
-  test-real-requests:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    env:
-      GEOENV_USE_MOCK: "false"
-    steps:
-      # Set up job requirements
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Check-out repository
-        uses: actions/checkout@v4
-      - name: Install poetry
-        uses: snok/install-poetry@v1
-      - name: Install package
-        run: poetry install --sync --with dev
-
-      # Test
-      - name: Test with pytest
-        run: poetry run pytest tests/
-
 
   cd:
     # Only run this job if the "ci" job passes

--- a/.github/workflows/test-real-requests.yml
+++ b/.github/workflows/test-real-requests.yml
@@ -1,0 +1,27 @@
+name: test-real-requests
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
+  pull_request:
+    branches:
+      - main  # The release branch
+
+jobs:
+  test-real-requests:
+    runs-on: ubuntu-latest
+    env:
+      GEOENV_USE_MOCK: "false"
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Check-out repository
+        uses: actions/checkout@v4
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+      - name: Install package
+        run: poetry install --sync --with dev
+      - name: Test with pytest
+        run: poetry run pytest tests/


### PR DESCRIPTION
Separate real request tests from the `ci-cd.yml` workflow to improve modularity and readability. Also, add a trigger for this workflow on pull requests to the main (release) branch.