### PR TITLE
feat: improve user agent string for HTTP requests (#43)

### DIFF
--- a/src/geoenv/utilities.py
+++ b/src/geoenv/utilities.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 import daiquiri
+import geoenv  # Import the package to access __version__
 
 logger = daiquiri.getLogger(__name__)
 
@@ -128,5 +129,6 @@ def user_agent() -> dict:
 
     :return: A dictionary containing the user agent string.
     """
-    header = {"user-agent": "geoenv Python package"}
+    version = getattr(geoenv, "__version__", "unknown")
+    header = {"user-agent": f"geoenv/{version} (+https://pypi.org/project/geoenv)"}
     return header

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -5,12 +5,10 @@ from importlib.resources import files
 
 import pytest
 
+import geoenv
 from geoenv.data_sources.world_terrestrial_ecosystems import apply_code_mapping
 from geoenv.geometry import Geometry
-from geoenv.utilities import (
-    EnvironmentDataModel,
-    get_properties,
-)
+from geoenv.utilities import EnvironmentDataModel, get_properties, user_agent
 from geoenv.response import Response, construct_response
 from tests.conftest import load_response
 
@@ -303,3 +301,13 @@ def test__to_schema_org_keywords(data_model):
     data.data["properties"]["environment"] = []
     keywords = data._to_schema_org_keywords()
     assert keywords is None
+
+
+def test_user_agent():
+    """Test the user_agent function returns the correct User-Agent header."""
+    header = user_agent()
+    assert isinstance(header, dict)
+    assert "user-agent" in header
+    expected = (f"geoenv/{getattr(geoenv, '__version__', 'unknown')} "
+                f"(+https://pypi.org/project/geoenv)")
+    assert header["user-agent"] == expected


### PR DESCRIPTION
Update the user_agent function to return a well-formed User-Agent string including the package name, dynamic version from geoenv.__version__, and PyPI URL. This enhances identification and traceability for data source providers. Also add a test to verify the correct User-Agent format.

Closes #43