### PR TITLE
docs: reorder top level documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ _Map geometries to environmental semantics_
 
 `geoenv` is a Python library that maps geospatial geometries, such as points and polygons, to standardized environmental terms. It’s like reverse geocoding, but for environments.
 
+## Motivation
+
+Finding datasets based on their environmental context is a challenge in data synthesis. The process often relies on vague or inconsistent metadata. This variability presents a barrier to reliable, large-scale analysis due to time lost in data discovery and incomplete search results.
+
+`geoenv` helps address this challenge by using a dataset’s originating location as a consistent and objective starting point. It can programmatically map the geometry of this location to standardized environmental terms, providing a scalable and repeatable method for generating interoperable metadata. This approach aims to enrich datasets with uniform, semantic metadata, making them potentially easier to discover, query, and integrate at scale.
+
+
+## Features
+
+- **Semantic Annotation:** Supplements inconsistent, manual descriptions with standardized environmental terms from controlled vocabularies.
+- **Structured, Interoperable Output:** Generates GeoJSON objects enriched with terms from [ENVO](https://sites.google.com/site/environmentontology/) (by default).
+- **Global Coverage:** Provides worldwide coverage for terrestrial, coastal, and marine environments using high-resolution data sources.
+- **Extensible:** Designed to accommodate new data sources or vocabularies for specific research needs.
+
+> Know of a useful data source or vocabulary? [Suggest it!](https://github.com/clnsmth/geoenv/issues)
+
 ## Quick Start
 
 Install from PyPI:
@@ -111,20 +127,6 @@ The response is a GeoJSON `Feature` with structured environmental descriptions m
 
 
 ```
-
-## Motivation
-
-Finding datasets based on their environmental context is a challenge in data synthesis. The process often relies on vague or inconsistent metadata. This variability presents a barrier to reliable, large-scale analysis due to time lost in data discovery and incomplete search results.
-
-`geoenv` helps address this challenge by using a dataset’s originating location as a consistent and objective starting point. It can programmatically map the geometry of this location to standardized environmental terms, providing a scalable and repeatable method for generating interoperable metadata. This approach aims to enrich datasets with uniform, semantic metadata, making them potentially easier to discover, query, and integrate at scale.
-
-
-## Features
-
-- **Semantic Annotation:** Supplements inconsistent, manual descriptions with standardized environmental terms from controlled vocabularies.
-- **Structured, Interoperable Output:** Generates GeoJSON objects enriched with terms from [ENVO](https://sites.google.com/site/environmentontology/) (by default).
-- **Global Coverage:** Provides worldwide coverage for terrestrial, coastal, and marine environments using high-resolution data sources.
-- **Extensible:** Designed to accommodate new data sources or vocabularies for specific research needs.
 
 ## Related Projects
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,23 @@ Release v\ |version|. (:ref:`Installation <quickstart>`)
 
 `geoenv` is a Python library that maps geospatial geometries, such as points and polygons, to standardized environmental terms. It’s like reverse geocoding, but for environments.
 
+Motivation
+----------
+
+Finding datasets based on their environmental context is a challenge in data synthesis. The process often relies on vague or inconsistent metadata. This variability presents a barrier to reliable, large-scale analysis due to time lost in data discovery and incomplete search results.
+
+`geoenv` helps address this challenge by using a dataset’s originating location as a consistent and objective starting point. It can programmatically map the geometry of this location to standardized environmental terms, providing a scalable and repeatable method for generating interoperable metadata. This approach aims to enrich datasets with uniform, semantic metadata, making them potentially easier to discover, query, and integrate at scale.
+
+Features
+--------
+
+- **Semantic Annotation:** Supplements inconsistent, manual descriptions with standardized environmental terms from controlled vocabularies.
+- **Structured, Interoperable Output:** Generates GeoJSON objects enriched with terms from `ENVO`_ (by default).
+- **Global Coverage:** Provides worldwide coverage for terrestrial, coastal, and marine environments using high-resolution data sources.
+- **Extensible:** Designed to accommodate new data sources or vocabularies for specific research needs.
+
+Know of a useful data source or vocabulary? `Suggest it! <https://github.com/clnsmth/geoenv/issues>`_
+
 .. _quickstart:
 
 Quick Start
@@ -126,21 +143,6 @@ The response is a GeoJSON `Feature` with structured environmental descriptions m
        ]
      }
    }
-
-Motivation
-----------
-
-Finding datasets based on their environmental context is a challenge in data synthesis. The process often relies on vague or inconsistent metadata. This variability presents a barrier to reliable, large-scale analysis due to time lost in data discovery and incomplete search results.
-
-`geoenv` helps address this challenge by using a dataset’s originating location as a consistent and objective starting point. It can programmatically map the geometry of this location to standardized environmental terms, providing a scalable and repeatable method for generating interoperable metadata. This approach aims to enrich datasets with uniform, semantic metadata, making them potentially easier to discover, query, and integrate at scale.
-
-Features
---------
-
-- **Semantic Annotation:** Supplements inconsistent, manual descriptions with standardized environmental terms from controlled vocabularies.
-- **Structured, Interoperable Output:** Generates GeoJSON objects enriched with terms from `ENVO`_ (by default).
-- **Global Coverage:** Provides worldwide coverage for terrestrial, coastal, and marine environments using high-resolution data sources.
-- **Extensible:** Designed to accommodate new data sources or vocabularies for specific research needs.
 
 Related Projects
 ----------------

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -308,6 +308,8 @@ def test_user_agent():
     header = user_agent()
     assert isinstance(header, dict)
     assert "user-agent" in header
-    expected = (f"geoenv/{getattr(geoenv, '__version__', 'unknown')} "
-                f"(+https://pypi.org/project/geoenv)")
+    expected = (
+        f"geoenv/{getattr(geoenv, '__version__', 'unknown')} "
+        f"(+https://pypi.org/project/geoenv)"
+    )
     assert header["user-agent"] == expected


### PR DESCRIPTION
Move the motivation and features sections back to the top to provide rationale and an overview of high-level features. This helps to delineate the problem space the project solves but shouldn't impede users looking only for the quickstart guide.

Partially reverts a5aa1158577deee0991a534797ce6346e798aeb4