### PR TITLE
ci: align test-real-requests.yml with ci.yml to fix failing test

### DIFF
--- a/.github/workflows/test-real-requests.yml
+++ b/.github/workflows/test-real-requests.yml
@@ -13,19 +13,23 @@ jobs:
     env:
       GEOENV_USE_MOCK: "false"
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
       - name: Check-out repository
         uses: actions/checkout@v4
 
-      - name: Install poetry
-        uses: snok/install-poetry@v1
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+          enable-cache: true
 
-      - name: Install package
-        run: poetry install --sync --with dev
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run Ruff formatter
+        run: uv run ruff format src/ tests/
+
+      - name: Run Ruff linter
+        run: uv run ruff check src/ tests/
 
       - name: Test with pytest
-        run: poetry run pytest tests/
+        run: uv run pytest tests/


### PR DESCRIPTION
This update brings the test-real-requests workflow up to date with the main CI workflow by switching to uv for package and environment management, and by running formatting and linting steps with ruff. These changes were previously made in the main CI workflow but were missing here.