### PR TITLE
test: add manual trigger for test-real-requests workflow

### DIFF
--- a/.github/workflows/test-real-requests.yml
+++ b/.github/workflows/test-real-requests.yml
@@ -3,6 +3,7 @@ name: test-real-requests
 on:
   schedule:
     - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add workflow_dispatch to allow manual workflow runs from GitHub UI to enable a rerun of the workflow after changes have been made to possibly fix issues that arise on the failed workflow.