### PR TITLE
feat(core): add get_version utility function

### DIFF
--- a/docs/source/user/api.rst
+++ b/docs/source/user/api.rst
@@ -59,3 +59,10 @@ Utilities
    :members:
    :exclude-members: EnvironmentDataModel, get_properties
 
+
+Package Version
+---------------
+
+.. autofunction:: geoenv.get_version
+
+

--- a/src/geoenv/__init__.py
+++ b/src/geoenv/__init__.py
@@ -1,5 +1,18 @@
 """geoenv"""
 
-from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 
-__version__ = version("geoenv")
+
+def get_version() -> str:
+    """
+    Returns the current semantic version of the geoenv package.
+    """
+    try:
+        return version("geoenv")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = get_version()
+
+__all__ = ["get_version"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+"""Test the package versioning utility"""
+
+from unittest.mock import patch
+from importlib.metadata import PackageNotFoundError
+import geoenv
+
+
+def test_get_version():
+    """Test that get_version returns a valid version string"""
+    version = geoenv.get_version()
+    assert isinstance(version, str)
+    assert len(version) > 0
+    assert version == geoenv.__version__
+
+
+def test_get_version_not_installed():
+    """Test that get_version returns 'unknown' when package is not installed"""
+    with patch("geoenv.version", side_effect=PackageNotFoundError):
+        version = geoenv.get_version()
+        assert version == "unknown"


### PR DESCRIPTION
Introduce a safe get_version() function to return the semantic package version, supporting a graceful fallback to "unknown" when the package is run in an uninstalled development environment.

- Add get_version() implementation to geoenv root __init__.py
- Add test suite in tests/test_version.py for normal and fallback modes
- Document the get_version utility in Sphinx developer API docs